### PR TITLE
Added new fields & deleted old fields from the database + updated database version

### DIFF
--- a/docs-core/src/main/resources/config.properties
+++ b/docs-core/src/main/resources/config.properties
@@ -1,1 +1,1 @@
-db.version=27
+db.version=28

--- a/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
@@ -1,0 +1,30 @@
+alter table T_DOCUMENT rename column DOC_TITLE_C to DOC_NAME_C;
+alter table T_DOCUMENT rename column DOC_DESCRIPTION_C to DOC_ADDITIONAL_NOTES_C;
+alter table T_DOCUMENT rename column DOC_CREATEDATE_D to DOC_APPLICATION_DATE_D;
+
+alter table T_DOCUMENT add column DOC_RESUME_C varchar(36) not null;
+alter table T_DOCUMENT add column DOC_GENDER_C varchar(500);
+alter table T_DOCUMENT add column DOC_COUNTRY_C varchar(500);
+alter table T_DOCUMENT add column DOC_RACE_C varchar(500);
+alter table T_DOCUMENT add column DOC_EMAIL_C varchar(500) not null;
+alter table T_DOCUMENT add column DOC_GRADMAJOR_C varchar(500) not null;
+alter table T_DOCUMENT add column DOC_UNDERGRAD_UNIV_C varchar(500) not null;
+alter table T_DOCUMENT add column DOC_MAJOR_C varchar(500) not null;
+alter table T_DOCUMENT add column DOC_MINOR_C varchar(500);
+alter table T_DOCUMENT add column DOC_GPA_C varchar(4) not null;
+alter table T_DOCUMENT add column DOC_MCAT_C int;
+alter table T_DOCUMENT add column DOC_LSAT_C int;
+alter table T_DOCUMENT add column DOC_GRE_C int;
+alter table T_DOCUMENT add column DOC_GMAT_C int;
+
+alter table T_DOCUMENT drop column DOC_LANGUAGE_C;
+alter table T_DOCUMENT drop column DOC_PUBLISHER_C;
+alter table T_DOCUMENT drop column DOC_TYPE_C;
+alter table T_DOCUMENT drop column DOC_COVERAGE_C;
+alter table T_DOCUMENT drop column DOC_RIGHTS_C;
+alter table T_DOCUMENT drop column DOC_SUBJECT_C;
+alter table T_DOCUMENT drop column DOC_FORMAT_C;
+alter table T_DOCUMENT drop column DOC_SOURCE_C;
+
+
+update T_CONFIG set CFG_VALUE_C = '28' where CFG_ID_C = 'DB_VERSION';


### PR DESCRIPTION
Altered the document database to include the following new fields:

Name, Additional Notes, Application Date, Resume, Gender, Country, Race, Email, Desired Program, Undergraduate University, Major, Minor, GPA, MCAT, LSAT, GRE, and GMAT

Also got rid of old metadata fields that were no longer relevant for a document meant to convey information regarding a grad school student applicant:

Language, Publisher, Type, Coverage, Rights, Subject, Format, and Source
(Kept Identifier as it is used elsewhere in the backend)

Finally, I also updated the configurations so that we're now on the latest update (Database Update #28). These changes should support the backend in implementing the new metadata changes and conveying the correct information between backend and frontend. 