### PR TITLE
Deleted extra resume and tag information from middleware and backend to fix 503 error

### DIFF
--- a/docs-core/src/main/java/com/sismics/docs/core/dao/DocumentDao.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/DocumentDao.java
@@ -87,7 +87,7 @@ public class DocumentDao {
         }
 
         EntityManager em = ThreadLocalContext.get().getEntityManager();
-        StringBuilder sb = new StringBuilder("select distinct d.DOC_ID_C, d.DOC_NAME_C, d.DOC_ADDITIONAL_NOTES_C, d.DOC_GENDER_C, d.DOC_COUNTRY_C, d.DOC_RACE_C, d.DOC_EMAIL_C, d.DOC_APPLICATION_DATE_D, d.DOC_RESUME_C, d.DOC_TAGS_C, d.DOC_GRADMAJOR_C, d.DOC_UNDERGRAD_UNIV_C, d.DOC_MAJOR_C, d.DOC_MINOR_C, d.DOC_GPA_C, d.DOC_MCAT_C, d.DOC_LSAT_C, d.DOC_GRE_C, d.DOC_GMAT_C, ");
+        StringBuilder sb = new StringBuilder("select distinct d.DOC_ID_C, d.DOC_NAME_C, d.DOC_ADDITIONAL_NOTES_C, d.DOC_GENDER_C, d.DOC_COUNTRY_C, d.DOC_RACE_C, d.DOC_EMAIL_C, d.DOC_APPLICATION_DATE_D, d.DOC_GRADMAJOR_C, d.DOC_UNDERGRAD_UNIV_C, d.DOC_MAJOR_C, d.DOC_MINOR_C, d.DOC_GPA_C, d.DOC_MCAT_C, d.DOC_LSAT_C, d.DOC_GRE_C, d.DOC_GMAT_C, ");
         sb.append(" (select count(s.SHA_ID_C) from T_SHARE s, T_ACL ac where ac.ACL_SOURCEID_C = d.DOC_ID_C and ac.ACL_TARGETID_C = s.SHA_ID_C and ac.ACL_DELETEDATE_D is null and s.SHA_DELETEDATE_D is null) shareCount, ");
         sb.append(" (select count(f.FIL_ID_C) from T_FILE f where f.FIL_DELETEDATE_D is null and f.FIL_IDDOC_C = d.DOC_ID_C) fileCount, ");
         sb.append(" u.USE_USERNAME_C ");
@@ -115,8 +115,6 @@ public class DocumentDao {
         documentDto.setRace((String) o[i++]);
         documentDto.setEmail((String) o[i++]);
         documentDto.setApplicationDate((String) o[i++]);
-        documentDto.setResume(((DocumentDto) o[i++]).getResume());
-        documentDto.setTags((List<String>) o[i++]);
         documentDto.setGradMajor((String) o[i++]);
         documentDto.setUndergradUniv((String) o[i++]);
         documentDto.setMajor((String) o[i++]);
@@ -215,8 +213,6 @@ public class DocumentDao {
         documentDb.setRace(document.getRace());
         documentDb.setEmail(document.getEmail());
         documentDb.setApplicationDate((Timestamp)document.getApplicationDate());
-        documentDb.setResume(document.getResume());
-        documentDb.setTags(document.getTags());
         documentDb.setGradMajor(document.getGradMajor());
         documentDb.setUndergradUniv(document.getUndergradUniv());
         documentDb.setMajor(document.getMajor());

--- a/docs-core/src/main/java/com/sismics/docs/core/dao/dto/DocumentDto.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/dao/dto/DocumentDto.java
@@ -110,11 +110,6 @@ public class DocumentDto {
     private String email;
 
     /**
-     * Resume.
-     */
-    private DocumentDto resume;
-
-    /**
      * Application date.
      */
     private String creation_date;
@@ -123,12 +118,6 @@ public class DocumentDto {
      * gradMajor.
      */
     private String desired_program;
-
-    /**
-     * Tags.
-     */
-    private List<String> tags;
-
     /**
      * Unergraduate university.
      */
@@ -204,15 +193,6 @@ public class DocumentDto {
         this.email = email;
     }
 
-
-    public DocumentDto getResume() {
-        return resume;
-    }
-
-    public void setResume(DocumentDto resume) {
-        this.resume = resume;
-    }
-
     public String getIdentifier() {
         return identifier;
     }
@@ -261,13 +241,7 @@ public class DocumentDto {
         this.additional_notes = additional_notes;
     }
 
-    public List<String> getTags() {
-        return tags;
-    }
 
-    public void setTags(List<String> tags) {
-        this.tags = tags;
-    }
     public String getGender() {
         return gender;
     }

--- a/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Document.java
+++ b/docs-core/src/main/java/com/sismics/docs/core/model/jpa/Document.java
@@ -102,17 +102,7 @@ public class Document implements Loggable {
     @Column(name = "DOC_APPLICATION_DATE_D", nullable = false, length = 100)
     private Date creation_date; 
 
-    /**
-    * Resume.
-    */
-    @Column(name = "DOC_RESUME_C", nullable = false, length = 100)
-    private Document resume; 
-
-    /**
-     * Tags. 
-     */
-    @Column(name = "DOC_TAGS_C", length = 100)
-    private List<String> tags; 
+   
 
     /**
      * Major. 
@@ -257,21 +247,6 @@ public class Document implements Loggable {
         return creation_date; 
     }
 
-    public Document getResume() {
-        return resume;
-    }
-
-    public void setResume(Document resume) {
-        this.resume = resume; 
-    }
-
-    public List<String> getTags() {
-        return tags;
-    }
-
-    public void setTags(List<String> tags) {
-        this.tags = tags;
-    }
 
     public String getGradMajor() {
         return desired_program; 

--- a/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
+++ b/docs-core/src/main/resources/db/update/dbupdate-028-0.sql
@@ -2,7 +2,6 @@ alter table T_DOCUMENT rename column DOC_TITLE_C to DOC_NAME_C;
 alter table T_DOCUMENT rename column DOC_DESCRIPTION_C to DOC_ADDITIONAL_NOTES_C;
 alter table T_DOCUMENT rename column DOC_CREATEDATE_D to DOC_APPLICATION_DATE_D;
 
-alter table T_DOCUMENT add column DOC_RESUME_C varchar(36) not null;
 alter table T_DOCUMENT add column DOC_GENDER_C varchar(500);
 alter table T_DOCUMENT add column DOC_COUNTRY_C varchar(500);
 alter table T_DOCUMENT add column DOC_RACE_C varchar(500);
@@ -17,6 +16,7 @@ alter table T_DOCUMENT add column DOC_LSAT_C int;
 alter table T_DOCUMENT add column DOC_GRE_C int;
 alter table T_DOCUMENT add column DOC_GMAT_C int;
 
+alter table T_DOCUMENT drop column DOC_RESUME_C;
 alter table T_DOCUMENT drop column DOC_LANGUAGE_C;
 alter table T_DOCUMENT drop column DOC_PUBLISHER_C;
 alter table T_DOCUMENT drop column DOC_TYPE_C;

--- a/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
+++ b/docs-web/src/main/java/com/sismics/docs/rest/resource/DocumentResource.java
@@ -725,7 +725,6 @@ public class DocumentResource extends BaseResource {
             @FormParam("race") String race,
             @FormParam("email") String email, 
             @FormParam("creation_Date") Date creation_dateStr,
-            @FormParam("resume") Document resume,
             @FormParam("tags") List<String> tagList,
             @FormParam("desired_program") String desired_program,
             @FormParam("undergrad_univ")String undergrad_univ,
@@ -765,7 +764,6 @@ public class DocumentResource extends BaseResource {
         document.setCountry(country);
         document.setRace(race);
         document.setEmail(email);
-        document.setResume(resume);
         document.setGradMajor(desired_program);
         document.setUndergradUniv(undergrad_univ);
         document.setMinor(minor);
@@ -774,7 +772,6 @@ public class DocumentResource extends BaseResource {
         document.setLSAT(lsat);
         document.setGRE(gre);
         document.setGMAT(gmat);
-        document.setTags(tagList);
         if (creation_dateStr == null) {
             document.setApplicationDate(new Date());
         } else {
@@ -851,7 +848,6 @@ public class DocumentResource extends BaseResource {
             @FormParam("race") String race,
             @FormParam("email") String email, 
             @FormParam("creation_Date") String creation_dateStr,
-            @FormParam("resume") Document resume,
             @FormParam("tags") List<String> tagList,
             @FormParam("desired_program") String desired_program,
             @FormParam("undergrad_univ")String undergrad_univ,
@@ -902,8 +898,6 @@ public class DocumentResource extends BaseResource {
         document.setCountry(country);
         document.setRace(race);
         document.setEmail(email);
-        document.setResume(resume);
-        document.setTags(tagList);
         document.setApplicationDate(new Date());
         
         documentDao.update(document, principal.getId());


### PR DESCRIPTION
Resume (file) information is currently jointly stored in the Document and File table, while tag information is stored in the Tag and Document_Tag tables. We previously overlooked this and simply added two new columns to the Document table, which was inconsistent with how Teedy's codebase works. By deleting the extraneous information, Teedy's backend is able to locate the correct columns for it to run successfully. 